### PR TITLE
Fix quickstart for python

### DIFF
--- a/python/tracing-to-zipkin/README.md
+++ b/python/tracing-to-zipkin/README.md
@@ -1,7 +1,7 @@
 #### Run it locally
 1. Clone the example repository: `git clone https://github.com/opencensus-otherwork/opencensus-quickstarts`
 2. Change to the example directory: `cd opencensus-quickstarts/python/tracing-to-zipkin`
-3. Install dependencies: `pip install opencensus`
+3. Install dependencies: `pip install opencensus opencensus-ext-zipkin`
 4. Download Zipkin: `curl -sSL https://zipkin.io/quickstart.sh | bash -s`
 5. Start Zipkin: `java -jar zipkin.jar`
 6. Run the code: `pyton tracingtozipkin.py`
@@ -20,7 +20,7 @@ import time
 import sys
 
 from opencensus.trace.tracer import Tracer
-from opencensus.trace.exporters.zipkin_exporter import ZipkinExporter
+from opencensus.ext.zipkin.trace_exporter import ZipkinExporter
 from opencensus.trace.samplers import always_on
 
 # 1a. Setup the exporter

--- a/python/tracing-to-zipkin/tracingtozipkin.py
+++ b/python/tracing-to-zipkin/tracingtozipkin.py
@@ -7,7 +7,7 @@ import sys
 
 from opencensus.trace.tracer import Tracer
 from opencensus.trace import time_event as time_event_module
-from opencensus.trace.exporters.zipkin_exporter import ZipkinExporter
+from opencensus.ext.zipkin.trace_exporter import ZipkinExporter
 from opencensus.trace.samplers import always_on
 
 # 1a. Setup the exporter


### PR DESCRIPTION
I noticed the python example linked [here](https://opencensus.io/quickstart/python/tracing/) no longer runs out of the box.

Zipkin Exporter is now part of the opencensus-ext-zipkin package, https://opencensus.io/exporters/supported-exporters/python/zipkin/