### PR TITLE
node.js: upgrade OpenCensus and Zipkin exporter to 0.0.19

### DIFF
--- a/node.js/package-lock.json
+++ b/node.js/package-lock.json
@@ -5,104 +5,139 @@
   "requires": true,
   "dependencies": {
     "@opencensus/core": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.7.tgz",
-      "integrity": "sha512-oZcCdFAId3bbdJaSAxeDqq0qdTbAQVcHMx0q4AvMU+vOrw/MEF+nyzCS2vN+B/8R9+CG1s0UBH6QzRx45RC61g==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.19.tgz",
+      "integrity": "sha512-Y5QXa7vggMU0+jveLcworfX9jNnztix7x1NraAV0uGkTp4y46HrFl0DnNcnNxUDvBu/cYeWRwlmhiWlr9+adOQ==",
       "requires": {
         "continuation-local-storage": "^3.2.1",
         "log-driver": "^1.2.7",
-        "semver": "^5.5.0",
+        "semver": "^6.0.0",
         "shimmer": "^1.2.0",
         "uuid": "^3.2.1"
       }
     },
     "@opencensus/exporter-zipkin": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/exporter-zipkin/-/exporter-zipkin-0.0.7.tgz",
-      "integrity": "sha512-7dYD/BOOaaN2lpsfwvg/J9jSf2A9weJrNvUzT0bY7Szg+MkCDp0D1F9RS9FA/5cM3LUXF8rhV9I9Ec4Hg2kixw==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/exporter-zipkin/-/exporter-zipkin-0.0.19.tgz",
+      "integrity": "sha512-23IuQH3QHFSsyMVtyPHSdMwZSWVrIImrpdyOHNywa2cZuYnMdBwF9cvsOx5HHP3/TzsPskJUDWA2LB7pEQ3+mQ==",
       "requires": {
-        "@opencensus/core": "^0.0.7"
+        "@opencensus/core": "^0.0.19"
       }
     },
     "@opencensus/instrumentation-all": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-all/-/instrumentation-all-0.0.7.tgz",
-      "integrity": "sha512-xRnjyRsLdY30DwcY+QB9KUWombDJmvUe5X27xe21TH7+N4TSSVQdQdEy/2N+2DN/gZDaCsiiZ2vW6NYOLAypZA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-all/-/instrumentation-all-0.0.19.tgz",
+      "integrity": "sha512-372k4B8eboXLGUhGsWbacD1uyNwtiUL2AWKcDBsjsBjvTLRsPdS2SajL+QpUKOhOGsF5HCjRQDKecxNqQIfr+w==",
       "requires": {
-        "@opencensus/instrumentation-grpc": "^0.0.7",
-        "@opencensus/instrumentation-http": "^0.0.7",
-        "@opencensus/instrumentation-http2": "^0.0.7",
-        "@opencensus/instrumentation-https": "^0.0.7",
-        "@opencensus/instrumentation-mongodb": "^0.0.7"
+        "@opencensus/instrumentation-grpc": "^0.0.19",
+        "@opencensus/instrumentation-http": "^0.0.19",
+        "@opencensus/instrumentation-http2": "^0.0.19",
+        "@opencensus/instrumentation-https": "^0.0.19",
+        "@opencensus/instrumentation-ioredis": "^0.0.19",
+        "@opencensus/instrumentation-mongodb": "^0.0.19",
+        "@opencensus/instrumentation-redis": "^0.0.19"
       }
     },
     "@opencensus/instrumentation-grpc": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-grpc/-/instrumentation-grpc-0.0.7.tgz",
-      "integrity": "sha512-HnF/4CcC9RVH+q9Dev6BFDLeTwZRwfYBbJPJ1sjKXMoBlQ/F05XoDkEWgaXLhXoYJfY6Rj36TnLRG4HmdCcrrA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-grpc/-/instrumentation-grpc-0.0.19.tgz",
+      "integrity": "sha512-/n5QJRfM+i6zuIF7WVuOiVfT5gRag8THcGRvEH0VdfKx9MHEHHxi+PJkKAvUty3DAuvW2kkvQX946nEhrn3Bvg==",
       "requires": {
-        "@opencensus/core": "^0.0.7",
-        "grpc": "~1.12.2",
-        "lodash": "^4.17.10",
-        "semver": "^5.5.0",
+        "@opencensus/core": "^0.0.19",
+        "@opencensus/propagation-binaryformat": "^0.0.19",
+        "grpc": "~1.21.0",
+        "lodash": "^4.17.11",
+        "object-sizeof": "^1.3.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-http": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http/-/instrumentation-http-0.0.7.tgz",
-      "integrity": "sha512-mi2x0SFcUQIGCYErif9QaspOO0oZe5uT9FBlHMmnxcmu8cdSIUQLMpDDYfRVW2qmKnOB0ZSY6QcOLIAa2mexmQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http/-/instrumentation-http-0.0.19.tgz",
+      "integrity": "sha512-xsfpqbn7M5iODN9TxBKAu3EunRMl7kp2F4sfwsUqWOKROKV3pOWREvyFwE7InxlCxy77Aik9wtFwe7g/mx94cw==",
       "requires": {
-        "@opencensus/core": "^0.0.7",
-        "end-of-stream": "^1.4.1",
-        "semver": "^5.5.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^3.2.1"
+        "@opencensus/core": "^0.0.19",
+        "semver": "^6.0.0",
+        "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-http2": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http2/-/instrumentation-http2-0.0.7.tgz",
-      "integrity": "sha512-hJlnRYwzF8W6SUwUWoDt3S6T5nXUBSkZ+upsO8JVcSbOBe2Z1nMaJPfdmDFjy6scD6ilSnGMsZqz9PmZh6nNJQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http2/-/instrumentation-http2-0.0.19.tgz",
+      "integrity": "sha512-VADBZtyLJdQmHvEi0QSAGrsocL2XQk8N9xQFCqoFeYrhvByKdomztMuWdGVzSEB8bcIQXNRBNnQNdWiQ5g2lnA==",
       "requires": {
-        "@opencensus/core": "^0.0.7",
-        "@opencensus/instrumentation-http": "^0.0.7",
-        "semver": "^5.5.0",
+        "@opencensus/core": "^0.0.19",
+        "@opencensus/instrumentation-http": "^0.0.19",
+        "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-https": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-https/-/instrumentation-https-0.0.7.tgz",
-      "integrity": "sha512-1yZZN1DqTCUFP/um3TXmBWsJtJkYVo4+IeZ6kKtsVj6OUBlW4XSwmteEBMzWT2JvRHOKge+UoGvfnnfS/LdmeA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-https/-/instrumentation-https-0.0.19.tgz",
+      "integrity": "sha512-i/J0+q6+baKUUY8rSdJt7t+cfNIVztK6/FPt8W+KQpBP53SZibK0W96+hThnL8gST6426SPsJ0J9SRf7isnw9A==",
       "requires": {
-        "@opencensus/core": "^0.0.7",
-        "@opencensus/instrumentation-http": "^0.0.7",
-        "semver": "^5.5.0",
+        "@opencensus/core": "^0.0.19",
+        "@opencensus/instrumentation-http": "^0.0.19",
+        "semver": "^6.0.0",
+        "shimmer": "^1.2.0"
+      }
+    },
+    "@opencensus/instrumentation-ioredis": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-ioredis/-/instrumentation-ioredis-0.0.19.tgz",
+      "integrity": "sha512-yw72y5qUCw8FZM2Lj/W51eubuh0IuTf5PSzGGxXHaDW0L2QoQOaKIoct6fiHIkKo8c4lpEwD6EOpb/8LaZHI4Q==",
+      "requires": {
+        "@opencensus/core": "^0.0.19",
+        "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-mongodb": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-mongodb/-/instrumentation-mongodb-0.0.7.tgz",
-      "integrity": "sha512-v/DU1X3IKq09C4SHP2FN8hUf3LXNEdJX7QK9uROUyZCsjBlbecwCKnMIC9LJcUQcFdagTrmz+KA7tFXwAYUjsA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-mongodb/-/instrumentation-mongodb-0.0.19.tgz",
+      "integrity": "sha512-8LHlWB8+PtPW4lqovpa94aNolHfz2mHJ0oj4AvbPx3affW5/2kYpK66Yo81WsLoP60dPo4zRFrNjB2lr7fb0Fw==",
       "requires": {
-        "@opencensus/core": "^0.0.7",
-        "end-of-stream": "^1.4.1",
-        "semver": "^5.5.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^3.2.1"
+        "@opencensus/core": "^0.0.19",
+        "shimmer": "^1.2.0"
+      }
+    },
+    "@opencensus/instrumentation-redis": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-redis/-/instrumentation-redis-0.0.19.tgz",
+      "integrity": "sha512-Qd3w8h16wAR49xRaxkv1Gz57uUiBvyw1VARjxO66mT4bcQFUb87I4VJT4aw/AQ3gJmCthvoWIxhOaUsQ+6PiAA==",
+      "requires": {
+        "@opencensus/core": "^0.0.19",
+        "semver": "^6.0.0",
+        "shimmer": "^1.2.0"
       }
     },
     "@opencensus/nodejs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/nodejs/-/nodejs-0.0.7.tgz",
-      "integrity": "sha512-/yVKaASAmCq0TLj6OhjV22fcFl+DiE/j8CWj42jxBsn9pDVNDWI3Sue2ufRkzHXhYJ4wBogYbiy81sifkBslig==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/nodejs/-/nodejs-0.0.19.tgz",
+      "integrity": "sha512-Qf6m9vaZOEQTxADWLWg3DC9OnbRMDUwkoxrrM5QwrLybWRleWNttSUHbIrma1iutNbgv8VBBazBH8yTZorekKQ==",
       "requires": {
-        "@opencensus/core": "^0.0.7",
-        "@opencensus/instrumentation-all": "^0.0.7",
-        "extend": "^3.0.1",
-        "require-in-the-middle": "^3.0.0"
+        "@opencensus/core": "^0.0.19",
+        "@opencensus/instrumentation-all": "^0.0.19",
+        "@opencensus/nodejs-base": "^0.0.19"
+      }
+    },
+    "@opencensus/nodejs-base": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/nodejs-base/-/nodejs-base-0.0.19.tgz",
+      "integrity": "sha512-pzhvCQv2HPVdhkazPf9U55pC9LU6jTvJjilWHI+3vnHXNOozDTGK/3UwIxvlLcwzi0K2qJ1ubOsHry38sanBtg==",
+      "requires": {
+        "@opencensus/core": "^0.0.19",
+        "extend": "^3.0.2",
+        "require-in-the-middle": "^4.0.0"
+      }
+    },
+    "@opencensus/propagation-binaryformat": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@opencensus/propagation-binaryformat/-/propagation-binaryformat-0.0.19.tgz",
+      "integrity": "sha512-az1nkZBx4Af8vF0E+6v0MVyyfm3FJIXSQb6rTPdzz6/Yj71rK/lLbFSMPbC8y7nKJQk5c5V/KU6dCFbPxyiHMw==",
+      "requires": {
+        "@opencensus/core": "^0.0.19"
       }
     },
     "ansi-regex": {
@@ -126,12 +161,24 @@
       "requires": {
         "semver": "^5.3.0",
         "shimmer": "^1.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -140,6 +187,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "bytebuffer": {
@@ -189,6 +245,14 @@
         "emitter-listener": "^1.1.1"
       }
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -202,14 +266,6 @@
         "shimmer": "^1.2.0"
       }
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -221,9 +277,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -234,13 +290,14 @@
       }
     },
     "grpc": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.12.4.tgz",
-      "integrity": "sha512-t0Hy4yoHHYLkK0b+ULTHw5ZuSFmWokCABY0C4bKQbE4jnm1hpjA23cQVD0xAqDcRHN5CkvFzlqb34ngV22dqoQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.21.1.tgz",
+      "integrity": "sha512-PFsZQazf62nP05a0xm23mlImMuw5oVlqF/0zakmsdqJgvbABe+d6VThY2PfhqJmWEL/FhQ6QNYsxS5EAM6++7g==",
       "requires": {
-        "lodash": "^4.17.5",
-        "nan": "^2.0.0",
-        "node-pre-gyp": "^0.10.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.13.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
@@ -277,7 +334,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true
         },
         "code-point-at": {
@@ -295,13 +352,6 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
         },
         "deep-extend": {
           "version": "0.6.0",
@@ -338,18 +388,6 @@
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1",
             "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -409,7 +447,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.3",
+          "version": "2.3.5",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -417,7 +455,7 @@
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -436,30 +474,39 @@
             }
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
         "needle": {
-          "version": "2.2.1",
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.13.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -474,11 +521,11 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.1",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -558,10 +605,24 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "safe-buffer": {
@@ -577,7 +638,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true
         },
         "set-blocking": {
@@ -616,13 +677,13 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.4",
+          "version": "4.4.8",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
@@ -644,10 +705,15 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true
         }
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -659,9 +725,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -685,9 +751,19 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -712,15 +788,28 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-sizeof": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.5.2.tgz",
+      "integrity": "sha512-5M9MYfLX3GsUv8YVSxypUkjQvpj5p3lX5gSaZCcV5973EqcQYp576vNU/620C1V6UaCdxeYGk3/QzEWz7uLvUQ==",
+      "requires": {
+        "buffer": "^5.4.3"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -737,7 +826,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -745,7 +834,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
@@ -765,31 +854,32 @@
       }
     },
     "require-in-the-middle": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-3.1.0.tgz",
-      "integrity": "sha512-90uK2zPUGdXZSz8eI5pHHvTl3qZRZ5FHxSOnjIYIwczRcP+fjokavi//UeN9i3i2O7UWCZHTgZtrrudpusSo1g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-4.0.1.tgz",
+      "integrity": "sha512-EfkM2zANyGkrfIExsECMeNn/uzjvHrE9h36yLXSavmrDiH4tgDNvltAmEKnt4PNLbqKPHZz+uszW2wTKrLUX0w==",
       "requires": {
+        "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
-        "resolve": "^1.5.0"
+        "resolve": "^1.12.0"
       }
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "string-width": {
       "version": "1.0.2",
@@ -803,16 +893,16 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "window-size": {
       "version": "0.1.4",
@@ -821,7 +911,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -840,7 +930,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",

--- a/node.js/package.json
+++ b/node.js/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@opencensus/exporter-zipkin": "0.0.19",
-    "@opencensus/nodejs": "0.0.19"
+    "@opencensus/exporter-zipkin": "^0.0.19",
+    "@opencensus/nodejs": "^0.0.19"
   }
 }

--- a/node.js/package.json
+++ b/node.js/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@opencensus/exporter-zipkin": "0.0.7",
-    "@opencensus/nodejs": "0.0.7"
+    "@opencensus/exporter-zipkin": "0.0.19",
+    "@opencensus/nodejs": "0.0.19"
   }
 }


### PR DESCRIPTION
II had problems with the older version on my Mac laptop although it worked ok on my more Linux desktop. This is resolved in the latest version.