### PR TITLE
go/tracing-to-zipkin: fix import path

### DIFF
--- a/go/tracing-to-zipkin/tracingtozipkin.go
+++ b/go/tracing-to-zipkin/tracingtozipkin.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"time"
 
-	"go.opencensus.io/exporter/zipkin"
+	"contrib.go.opencensus.io/exporter/zipkin"
 	"go.opencensus.io/trace"
 
 	openzipkin "github.com/openzipkin/zipkin-go"


### PR DESCRIPTION
zipkin exporter was moved to contrib.go.opencensus.io in 0.21.0